### PR TITLE
Updated for CommandExecutor interface

### DIFF
--- a/src/main/java/com/dinnerbone/bukkit/sample/SampleDebugCommand.java
+++ b/src/main/java/com/dinnerbone/bukkit/sample/SampleDebugCommand.java
@@ -1,0 +1,31 @@
+
+package com.dinnerbone.bukkit.sample;
+
+import org.bukkit.entity.Player;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+/**
+ * Handler for the /debug sample command.
+ * @author SpaceManiac
+ */
+public class SampleDebugCommand implements CommandExecutor {
+    private final SamplePlugin plugin;
+
+    public SampleDebugCommand(SamplePlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] split) {
+        if (sender instanceof Player) {
+            Player player = (Player) sender;
+            plugin.setDebugging(player, !plugin.isDebugging(player));
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/dinnerbone/bukkit/sample/SamplePlayerListener.java
+++ b/src/main/java/com/dinnerbone/bukkit/sample/SamplePlayerListener.java
@@ -2,8 +2,6 @@
 package com.dinnerbone.bukkit.sample;
 
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerChatEvent;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.event.player.PlayerListener;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -27,38 +25,6 @@ public class SamplePlayerListener extends PlayerListener {
     @Override
     public void onPlayerQuit(PlayerEvent event) {
         System.out.println(event.getPlayer().getName() + " left the server! :'(");
-    }
-
-    @Override
-    public void onPlayerCommand(PlayerChatEvent event) {
-        String[] split = event.getMessage().split(" ");
-        Player player = event.getPlayer();
-
-        if (split[0].equalsIgnoreCase("/pos")) {
-            if (split.length == 1) {
-                Location location = player.getLocation();
-                player.sendMessage("You are currently at " + location.getX() +"," + location.getY() + "," + location.getZ() +
-                        " with " + location.getYaw() + " yaw and " + location.getPitch() + " pitch");
-            } else if (split.length == 4) {
-                try {
-                    double x = Double.parseDouble(split[1]);
-                    double y = Double.parseDouble(split[2]);
-                    double z = Double.parseDouble(split[3]);
-
-                    player.teleportTo(new Location(player.getWorld(), x, y, z));
-                } catch (NumberFormatException ex) {
-                    player.sendMessage("Given location is invalid");
-                }
-            } else {
-                player.sendMessage("Usage: '/pos' to get current position, or '/pos x y z' to teleport to x,y,z");
-            }
-
-            event.setCancelled(true);
-        } else if (split[0].equalsIgnoreCase("/debug")) {
-            plugin.setDebugging(player, !plugin.isDebugging(player));
-
-            event.setCancelled(true);
-        }
     }
 
     @Override

--- a/src/main/java/com/dinnerbone/bukkit/sample/SamplePlugin.java
+++ b/src/main/java/com/dinnerbone/bukkit/sample/SamplePlugin.java
@@ -1,14 +1,11 @@
 
 package com.dinnerbone.bukkit.sample;
 
-import java.io.File;
 import java.util.HashMap;
 import org.bukkit.entity.Player;
-import org.bukkit.Server;
 import org.bukkit.event.Event.Priority;
 import org.bukkit.event.Event;
 import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.PluginLoader;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.PluginManager;
 
@@ -42,10 +39,13 @@ public class SamplePlugin extends JavaPlugin {
         PluginManager pm = getServer().getPluginManager();
         pm.registerEvent(Event.Type.PLAYER_JOIN, playerListener, Priority.Normal, this);
         pm.registerEvent(Event.Type.PLAYER_QUIT, playerListener, Priority.Normal, this);
-        pm.registerEvent(Event.Type.PLAYER_COMMAND, playerListener, Priority.Normal, this);
         pm.registerEvent(Event.Type.PLAYER_MOVE, playerListener, Priority.Normal, this);
         pm.registerEvent(Event.Type.BLOCK_PHYSICS, blockListener, Priority.Normal, this);
         pm.registerEvent(Event.Type.BLOCK_CANBUILD, blockListener, Priority.Normal, this);
+
+        // Register our commands
+        getCommand("pos").setExecutor(new SamplePosCommand(this));
+        getCommand("debug").setExecutor(new SampleDebugCommand(this));
 
         // EXAMPLE: Custom code, here we just output some info so we can check all is well
         PluginDescriptionFile pdfFile = this.getDescription();

--- a/src/main/java/com/dinnerbone/bukkit/sample/SamplePosCommand.java
+++ b/src/main/java/com/dinnerbone/bukkit/sample/SamplePosCommand.java
@@ -1,0 +1,48 @@
+
+package com.dinnerbone.bukkit.sample;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+/**
+ * Handler for the /pos sample command.
+ * @author SpaceManiac
+ */
+public class SamplePosCommand implements CommandExecutor {
+    private final SamplePlugin plugin;
+
+    public SamplePosCommand(SamplePlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] split) {
+        if (!(sender instanceof Player)) {
+            return false;
+        }
+        Player player = (Player) sender;
+
+        if (split.length == 0) {
+            Location location = player.getLocation();
+            player.sendMessage("You are currently at " + location.getX() +"," + location.getY() + "," + location.getZ() +
+                    " with " + location.getYaw() + " yaw and " + location.getPitch() + " pitch");
+            return true;
+        } else if (split.length == 3) {
+            try {
+                double x = Double.parseDouble(split[0]);
+                double y = Double.parseDouble(split[1]);
+                double z = Double.parseDouble(split[2]);
+
+                player.teleportTo(new Location(player.getWorld(), x, y, z));
+            } catch (NumberFormatException ex) {
+                player.sendMessage("Given location is invalid");
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,3 +1,10 @@
 name: Sample Plugin
 main: com.dinnerbone.bukkit.sample.SamplePlugin
 version: 0.4
+commands:
+  pos:
+    description: Displays your position or teleports you to another.
+    usage: "Usage: '/pos' to get current position, or '/pos x y z' to teleport to x,y,z"
+  debug:
+    description: Toggles your debugging status for this plugin.
+    usage: /debug


### PR DESCRIPTION
I noticed a few people mentioning that the sample plugin hadn't been updated for the new interface yet, so I went ahead and did so.

I noticed as well that neither of the BlockListener functions (the sand/gravel holding up and cactus freeform placement) seem to do their thing, but that's a separate issue.
