### PR TITLE
Fix plugin `Sample_Plugin v0.5' uses the space-character (0x20) in its name `Sample Plugin' - this is discouraged

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
-name: Sample Plugin
+name: SamplePlugin
 main: com.dinnerbone.bukkit.sample.SamplePlugin
 version: ${version}
 commands:


### PR DESCRIPTION
This sample plugin uses a discouraged practice according to CraftBukkit 1.7.9-R0.1:

```
Loading libraries, please wait...
[11:09:06 INFO]: Starting minecraft server version 1.7.9
[11:09:06 INFO]: Loading properties
[11:09:06 INFO]: Default game type: SURVIVAL
[11:09:06 INFO]: Generating keypair
[11:09:06 INFO]: Starting Minecraft server on *:25565
[11:09:06 INFO]: This server is running CraftBukkit version git-Bukkit-1.7.9-R0.1-b3084jnks (MC: 1.7.9) (Implementing API version 1.7.9-R0.1)
[11:09:06 WARN]: Plugin `Sample_Plugin v0.5' uses the space-character (0x20) in its name `Sample Plugin' - this is discouraged
[11:09:06 INFO]: [Sample_Plugin] Loading Sample_Plugin v0.5
```

so I removed the space in `plugin.yml`, fixing the warning:

```
cb $ java -mx2G -jar craftbukkit-1.7.9-R0.1.jar 
Loading libraries, please wait...
[11:10:51 INFO]: Starting minecraft server version 1.7.9
[11:10:51 INFO]: Loading properties
[11:10:51 INFO]: Default game type: SURVIVAL
[11:10:51 INFO]: Generating keypair
[11:10:51 INFO]: Starting Minecraft server on *:25565
[11:10:51 INFO]: This server is running CraftBukkit version git-Bukkit-1.7.9-R0.1-b3084jnks (MC: 1.7.9) (Implementing API version 1.7.9-R0.1)
[11:10:51 INFO]: [SamplePlugin] Loading SamplePlugin v0.5
```
