### PR TITLE
Correct scope of Bukkit API dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
       <artifactId>bukkit</artifactId>
       <version>1.4.6-R0.3</version>
       <type>jar</type>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The org.bukkit:bukkit dependency was scoped to "compile", which will cause it to be included in the plugin jar with [maven-shade-plugin](https://maven.apache.org/components/plugins/maven-shade-plugin/), for example. This can be avoided with exclusions but a cleaner fix is to change the scope to "provided", as this is the intended purpose: dependencies provided at runtime.

From the [Maven documentation](http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope):

> provided
> This is much like compile, but indicates you expect the JDK or a container to provide the dependency at runtime. For example, when building a web application for the Java Enterprise Edition, you would set the dependency on the Servlet API and related Java EE APIs to scope provided because the web container provides those classes. This scope is only available on the compilation and test classpath, and is not transitive.

This accurately describes the Bukkit API dependency.